### PR TITLE
createJSModules is no longer a part of ReactPackage

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
@@ -22,7 +22,7 @@ public class OrientationPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Don't override createJSModules since it's no longer a part of ReactPackage